### PR TITLE
feat: updated GetAllTaskInstancesAndDagRuns function

### DIFF
--- a/pkg/client/dagrun.go
+++ b/pkg/client/dagrun.go
@@ -48,6 +48,7 @@ func (c *AirflowClient) GetLatestDagRun(dagId string) (*airflow.DAGRun, error) {
 		return nil, err
 	}
 
+	// Doesn't work after 99th dag run
 	nRuns := len(*dagRuns.DagRuns)
 	if len(*dagRuns.DagRuns) == 0 {
 		return nil, fmt.Errorf("no dag runs found for %s", dagId)

--- a/pkg/client/model.go
+++ b/pkg/client/model.go
@@ -10,7 +10,7 @@ import (
 type DagRunInfo struct {
 	DagId     string
 	DagRunId  string // Could use airflow.NullableString but think processing to string will make it easier
-	StartDate time.Time
-	EndDate   time.Time
-	Status    airflow.DagState
+	StartDate *time.Time
+	EndDate   *time.Time
+	Status    *airflow.DagState
 }

--- a/pkg/client/model.go
+++ b/pkg/client/model.go
@@ -2,12 +2,15 @@ package client
 
 import (
 	"time"
+
+	"github.com/apache/airflow-client-go/airflow"
 )
 
 // Define a struct for DAG run information
 type DagRunInfo struct {
+	DagId     string
 	DagRunId  string // Could use airflow.NullableString but think processing to string will make it easier
 	StartDate time.Time
 	EndDate   time.Time
-	Status    string
+	Status    airflow.DagState
 }

--- a/pkg/client/task.go
+++ b/pkg/client/task.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/apache/airflow-client-go/airflow"
 	"golang.org/x/net/context"
@@ -99,11 +100,19 @@ func (c *AirflowClient) GetAllTaskInstancesAndDagRuns(dagId string) ([]airflow.T
 	var allDagRunsInfo []DagRunInfo
 	var allTaskInstances []airflow.TaskInstanceCollection
 	for _, dagRun := range *dagRuns.DagRuns {
+
+		// If the dag run hasn't completed, enddate = now
+		startdate := *dagRun.StartDate.Get()
+		enddate := time.Time{} // EndDate might be null so we initialise with empty time
+		if dagRun.EndDate.Get() == nil {
+			enddate = time.Now()
+		}
+
 		// Insert Dag run info into struct then append to dag list
 		dagRunStruct := DagRunInfo{
 			DagRunId:  string(*dagRun.DagRunId.Get()),
-			StartDate: *dagRun.StartDate.Get(),
-			EndDate:   *dagRun.EndDate.Get(),
+			StartDate: startdate,
+			EndDate:   enddate,
 			Status:    string(*dagRun.State),
 		}
 		allDagRunsInfo = append(allDagRunsInfo, dagRunStruct)

--- a/pkg/client/task.go
+++ b/pkg/client/task.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/apache/airflow-client-go/airflow"
 	"golang.org/x/net/context"
@@ -101,20 +100,13 @@ func (c *AirflowClient) GetAllTaskInstancesAndDagRuns(dagId string) ([]airflow.T
 	var allTaskInstances []airflow.TaskInstanceCollection
 	for _, dagRun := range *dagRuns.DagRuns {
 
-		// If the dag run hasn't completed, enddate = now
-		startdate := *dagRun.StartDate.Get()
-		enddate := time.Time{} // EndDate might be null so we initialise with empty time
-		if dagRun.EndDate.Get() == nil {
-			enddate = time.Now()
-		}
-
 		// Insert Dag run info into struct then append to dag list
 		dagRunStruct := DagRunInfo{
 			DagId:     dagId,
 			DagRunId:  string(*dagRun.DagRunId.Get()),
-			StartDate: startdate,
-			EndDate:   enddate,
-			Status:    *dagRun.State,
+			StartDate: dagRun.StartDate.Get(),
+			EndDate:   dagRun.EndDate.Get(),
+			Status:    dagRun.State,
 		}
 		allDagRunsInfo = append(allDagRunsInfo, dagRunStruct)
 

--- a/pkg/client/task.go
+++ b/pkg/client/task.go
@@ -110,10 +110,11 @@ func (c *AirflowClient) GetAllTaskInstancesAndDagRuns(dagId string) ([]airflow.T
 
 		// Insert Dag run info into struct then append to dag list
 		dagRunStruct := DagRunInfo{
+			DagId:     dagId,
 			DagRunId:  string(*dagRun.DagRunId.Get()),
 			StartDate: startdate,
 			EndDate:   enddate,
-			Status:    string(*dagRun.State),
+			Status:    *dagRun.State,
 		}
 		allDagRunsInfo = append(allDagRunsInfo, dagRunStruct)
 


### PR DESCRIPTION
Updated GetAllTaskInstancesAndDagRuns() so that it now doesn't break/error when the EndDate is nil (i.e., DagRun hasn't completed yet). It will instead, populate with current time of query. 