### PR TITLE
feat: unpause paused dag within ExecuteDagRun

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -25,6 +25,7 @@ type AirflowClientInterface interface {
 	GetTaskInstanceForAllDagRuns(dagId string, taskId string) ([]airflow.TaskInstance, error)
 	GetTaskInstancesForLatestDagRun(dagId string) (airflow.TaskInstanceCollection, error)
 	GetAllTaskInstancesAndDagRuns(dagId string) ([]airflow.TaskInstanceCollection, []DagRunInfo, error)
+	UnpauseDag(dagId string) error
 }
 
 type AirflowClient struct {

--- a/pkg/client/dag.go
+++ b/pkg/client/dag.go
@@ -1,7 +1,10 @@
 package client
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/apache/airflow-client-go/airflow"
 	"golang.org/x/net/context"
@@ -22,4 +25,52 @@ func (c *AirflowClient) GetDag(dagId string) (*airflow.DAG, error) {
 	}
 
 	return &dagDetails, nil
+}
+
+func (c *AirflowClient) UnpauseDag(dagId string) error {
+	dag, err := c.GetDag(dagId)
+	if err != nil {
+		return err
+	}
+
+	isPaused := dag.IsPaused.Get()
+
+	if isPaused == nil || *isPaused {
+		err := c.unpauseDagRequest(dagId)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *AirflowClient) unpauseDagRequest(dagId string) error {
+	body := map[string]bool{"is_paused": false}
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("%s://%s/api/v1/dags/%s?update_mask=is_paused", c.airflowConfig.Scheme, c.airflowConfig.Host, dagId)
+
+	req, err := http.NewRequest("PATCH", url, bytes.NewBuffer(jsonBody))
+	if err != nil {
+		return err
+	}
+
+	req.SetBasicAuth(c.airflowCredentials.UserName, c.airflowCredentials.Password)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("request failed")
+	}
+
+	return nil
 }

--- a/pkg/client/execute.go
+++ b/pkg/client/execute.go
@@ -9,6 +9,12 @@ import (
 
 func (c *AirflowClient) ExecuteDagRun(dagId string) (*airflow.DAGRun, error) {
 	ctx := context.WithValue(context.Background(), airflow.ContextBasicAuth, c.airflowCredentials)
+
+	err := c.UnpauseDag(dagId)
+	if err != nil {
+		return nil, err
+	}
+
 	executeDagRunRequest := c.airflowClient.DAGRunApi.PostDagRun(ctx, dagId)
 	executeDagRunRequest = executeDagRunRequest.DAGRun(*airflow.NewDAGRunWithDefaults())
 


### PR DESCRIPTION
Unpausing a paused dags during a ExecuteDagRun. This has to use the raw REST API as the is_paused attribute cannot be modified via API patch method.